### PR TITLE
Solution to your scroll view versus auto layout issue.

### DIFF
--- a/TestAL.xcodeproj/project.pbxproj
+++ b/TestAL.xcodeproj/project.pbxproj
@@ -355,12 +355,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Frameworks",
-				);
 				INFOPLIST_FILE = TestAL/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -370,12 +365,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Frameworks",
-				);
 				INFOPLIST_FILE = TestAL/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};

--- a/TestAL/Base.lproj/Main.storyboard
+++ b/TestAL/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -56,40 +56,39 @@
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bkm-bG-pPB" userLabel="ContentView">
                                         <rect key="frame" x="0.0" y="0.0" width="600" height="536"/>
                                         <subviews>
-                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Third" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jgL-Vq-buA">
-                                                <rect key="frame" x="187" y="453" width="226" height="30"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Top" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sqj-YQ-sTU">
+                                                <rect key="frame" x="286" y="72" width="28" height="21"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="226" id="Xj7-Mi-5QZ"/>
+                                                    <constraint firstAttribute="height" constant="21" id="C2o-Tx-CIe"/>
                                                 </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="First" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="t1n-Fd-d23">
+                                                <rect key="frame" x="187" y="353" width="226" height="30"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no"/>
                                             </textField>
                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Second" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Ld1-9V-tEL">
                                                 <rect key="frame" x="187" y="403" width="226" height="30"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no"/>
+                                            </textField>
+                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Third" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jgL-Vq-buA">
+                                                <rect key="frame" x="187" y="453" width="226" height="30"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="226" id="BZE-TI-ehA"/>
+                                                    <constraint firstAttribute="width" constant="226" id="Dce-dY-SYO"/>
+                                                    <constraint firstAttribute="height" constant="30" id="aQL-UM-WjL"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no"/>
                                             </textField>
-                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="First" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="t1n-Fd-d23">
-                                                <rect key="frame" x="187" y="353" width="226" height="30"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="226" id="f3Z-Ne-Fje"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no"/>
-                                            </textField>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Top" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sqj-YQ-sTU">
-                                                <rect key="frame" x="287" y="72" width="28" height="21"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Kb5-dn-QTd">
-                                                <rect key="frame" x="272" y="498" width="57" height="30"/>
+                                                <rect key="frame" x="271" y="498" width="57" height="30"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="57" id="If7-or-eKp"/>
+                                                    <constraint firstAttribute="height" constant="30" id="1oY-AB-WVd"/>
+                                                    <constraint firstAttribute="width" constant="57" id="Jzl-n7-afB"/>
                                                 </constraints>
                                                 <state key="normal" title="Done">
                                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
@@ -101,37 +100,75 @@
                                         </subviews>
                                         <color key="backgroundColor" red="1" green="0.80000001190000003" blue="0.40000000600000002" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
-                                            <constraint firstItem="Kb5-dn-QTd" firstAttribute="centerX" secondItem="bkm-bG-pPB" secondAttribute="centerX" id="JB4-tD-VB8"/>
-                                            <constraint firstItem="jgL-Vq-buA" firstAttribute="top" secondItem="Ld1-9V-tEL" secondAttribute="bottom" constant="20" id="POu-PX-1md"/>
-                                            <constraint firstItem="t1n-Fd-d23" firstAttribute="top" secondItem="bkm-bG-pPB" secondAttribute="top" constant="353" id="SLa-Yr-uDh"/>
-                                            <constraint firstAttribute="centerX" secondItem="jgL-Vq-buA" secondAttribute="centerX" id="bAI-Ep-7oy"/>
-                                            <constraint firstAttribute="centerX" secondItem="Ld1-9V-tEL" secondAttribute="centerX" id="c0c-Wi-upf"/>
-                                            <constraint firstAttribute="centerX" secondItem="Sqj-YQ-sTU" secondAttribute="centerX" constant="-1" id="cww-5W-ga8"/>
-                                            <constraint firstItem="Sqj-YQ-sTU" firstAttribute="top" secondItem="bkm-bG-pPB" secondAttribute="top" constant="72" id="fbH-nz-prc"/>
-                                            <constraint firstItem="Ld1-9V-tEL" firstAttribute="top" secondItem="t1n-Fd-d23" secondAttribute="bottom" constant="20" id="jc9-6B-HxU"/>
-                                            <constraint firstAttribute="bottom" secondItem="Kb5-dn-QTd" secondAttribute="bottom" constant="8" id="oUO-d7-508"/>
-                                            <constraint firstAttribute="centerX" secondItem="t1n-Fd-d23" secondAttribute="centerX" id="r0T-VZ-PFV"/>
-                                            <constraint firstAttribute="height" constant="536" id="yFi-NP-kjE"/>
+                                            <constraint firstItem="Ld1-9V-tEL" firstAttribute="top" secondItem="t1n-Fd-d23" secondAttribute="bottom" constant="20" id="7eD-0K-axk"/>
+                                            <constraint firstItem="Sqj-YQ-sTU" firstAttribute="top" secondItem="bkm-bG-pPB" secondAttribute="top" constant="72" id="9Xk-Wn-KvV"/>
+                                            <constraint firstAttribute="bottom" secondItem="Kb5-dn-QTd" secondAttribute="bottom" constant="8" id="Gwl-Q8-BA0"/>
+                                            <constraint firstItem="jgL-Vq-buA" firstAttribute="top" secondItem="Ld1-9V-tEL" secondAttribute="bottom" constant="20" id="Pvh-Xz-W9K"/>
+                                            <constraint firstItem="Ld1-9V-tEL" firstAttribute="trailing" secondItem="jgL-Vq-buA" secondAttribute="trailing" id="SNp-eF-Rqa"/>
+                                            <constraint firstAttribute="centerX" secondItem="Kb5-dn-QTd" secondAttribute="centerX" id="VIS-4B-aIs"/>
+                                            <constraint firstItem="Ld1-9V-tEL" firstAttribute="height" secondItem="jgL-Vq-buA" secondAttribute="height" id="cHh-ru-ego"/>
+                                            <constraint firstItem="Ld1-9V-tEL" firstAttribute="leading" secondItem="jgL-Vq-buA" secondAttribute="leading" id="ceE-XJ-hwI"/>
+                                            <constraint firstItem="jgL-Vq-buA" firstAttribute="trailing" secondItem="t1n-Fd-d23" secondAttribute="trailing" id="dEe-ez-4UO"/>
+                                            <constraint firstAttribute="height" constant="536" id="gla-Ao-JP8"/>
+                                            <constraint firstAttribute="centerX" secondItem="jgL-Vq-buA" secondAttribute="centerX" id="gz6-vs-XON"/>
+                                            <constraint firstItem="Kb5-dn-QTd" firstAttribute="top" secondItem="jgL-Vq-buA" secondAttribute="bottom" constant="15" id="in4-OU-zNS"/>
+                                            <constraint firstAttribute="centerX" secondItem="Sqj-YQ-sTU" secondAttribute="centerX" id="kDt-6y-GZN"/>
+                                            <constraint firstItem="jgL-Vq-buA" firstAttribute="leading" secondItem="t1n-Fd-d23" secondAttribute="leading" id="l5u-0C-cOv"/>
+                                            <constraint firstItem="jgL-Vq-buA" firstAttribute="height" secondItem="t1n-Fd-d23" secondAttribute="height" id="zwr-EZ-nvW"/>
                                         </constraints>
                                     </view>
                                 </subviews>
                                 <color key="backgroundColor" red="0.40000000600000002" green="0.40000000600000002" blue="0.40000000600000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
-                                    <constraint firstItem="bkm-bG-pPB" firstAttribute="centerX" secondItem="eNj-JM-U7b" secondAttribute="centerX" id="0Tr-x8-uv7"/>
-                                    <constraint firstAttribute="trailing" secondItem="bkm-bG-pPB" secondAttribute="trailing" id="Guq-tK-JCX"/>
-                                    <constraint firstItem="bkm-bG-pPB" firstAttribute="leading" secondItem="eNj-JM-U7b" secondAttribute="leading" id="URF-y7-9mM"/>
-                                    <constraint firstAttribute="bottom" secondItem="bkm-bG-pPB" secondAttribute="bottom" id="dZ0-Bo-QhA"/>
-                                    <constraint firstItem="bkm-bG-pPB" firstAttribute="top" secondItem="eNj-JM-U7b" secondAttribute="top" id="oWp-XL-Yc9"/>
+                                    <constraint firstAttribute="height" secondItem="bkm-bG-pPB" secondAttribute="height" id="3jE-SR-pVA"/>
+                                    <constraint firstAttribute="width" secondItem="bkm-bG-pPB" secondAttribute="width" id="3zf-Xd-KgP"/>
+                                    <constraint firstItem="bkm-bG-pPB" firstAttribute="top" secondItem="eNj-JM-U7b" secondAttribute="top" id="4Cg-Lr-uKV"/>
+                                    <constraint firstAttribute="height" secondItem="bkm-bG-pPB" secondAttribute="height" id="4i3-jj-vWO"/>
+                                    <constraint firstAttribute="trailing" secondItem="bkm-bG-pPB" secondAttribute="trailing" id="5S9-M6-T12"/>
+                                    <constraint firstAttribute="bottom" secondItem="bkm-bG-pPB" secondAttribute="bottom" id="Fni-Bf-zXu"/>
+                                    <constraint firstItem="bkm-bG-pPB" firstAttribute="leading" secondItem="eNj-JM-U7b" secondAttribute="leading" id="GnR-S7-T1n"/>
+                                    <constraint firstAttribute="trailing" secondItem="bkm-bG-pPB" secondAttribute="trailing" id="Lbn-do-KhH"/>
+                                    <constraint firstItem="bkm-bG-pPB" firstAttribute="top" secondItem="eNj-JM-U7b" secondAttribute="top" id="TUB-QR-I4j"/>
+                                    <constraint firstAttribute="width" secondItem="bkm-bG-pPB" secondAttribute="width" id="aMR-7c-Qib"/>
+                                    <constraint firstItem="bkm-bG-pPB" firstAttribute="width" secondItem="eNj-JM-U7b" secondAttribute="width" id="hBl-SR-2tc"/>
+                                    <constraint firstAttribute="height" secondItem="bkm-bG-pPB" secondAttribute="height" id="i1b-Ak-Kx1"/>
+                                    <constraint firstItem="bkm-bG-pPB" firstAttribute="leading" secondItem="eNj-JM-U7b" secondAttribute="leading" id="n9M-3h-iwn"/>
+                                    <constraint firstAttribute="bottom" secondItem="bkm-bG-pPB" secondAttribute="bottom" id="vD3-kR-Ohb"/>
+                                    <constraint firstAttribute="centerX" secondItem="bkm-bG-pPB" secondAttribute="centerX" id="vTy-xQ-DFn"/>
                                 </constraints>
+                                <variation key="default">
+                                    <mask key="constraints">
+                                        <exclude reference="3jE-SR-pVA"/>
+                                        <exclude reference="3zf-Xd-KgP"/>
+                                        <exclude reference="4Cg-Lr-uKV"/>
+                                        <exclude reference="4i3-jj-vWO"/>
+                                        <exclude reference="5S9-M6-T12"/>
+                                        <exclude reference="GnR-S7-T1n"/>
+                                        <exclude reference="hBl-SR-2tc"/>
+                                        <exclude reference="i1b-Ak-Kx1"/>
+                                        <exclude reference="vD3-kR-Ohb"/>
+                                        <exclude reference="vTy-xQ-DFn"/>
+                                    </mask>
+                                </variation>
                             </scrollView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="eNj-JM-U7b" firstAttribute="top" secondItem="iwE-5s-5wc" secondAttribute="topMargin" constant="64" id="2Ct-pN-QLI"/>
-                            <constraint firstItem="s7i-pd-zJw" firstAttribute="top" secondItem="eNj-JM-U7b" secondAttribute="bottom" id="m6i-WB-pS3"/>
-                            <constraint firstItem="eNj-JM-U7b" firstAttribute="leading" secondItem="iwE-5s-5wc" secondAttribute="leading" id="ubx-dr-i9L"/>
-                            <constraint firstAttribute="trailing" secondItem="eNj-JM-U7b" secondAttribute="trailing" id="yTW-FT-0k1"/>
+                            <constraint firstAttribute="height" secondItem="bkm-bG-pPB" secondAttribute="height" id="9gL-hj-Scz"/>
+                            <constraint firstAttribute="height" secondItem="bkm-bG-pPB" secondAttribute="height" id="AEi-r1-z7b"/>
+                            <constraint firstItem="eNj-JM-U7b" firstAttribute="top" secondItem="JmO-x4-U0z" secondAttribute="bottom" id="Dyf-3L-wo2"/>
+                            <constraint firstItem="s7i-pd-zJw" firstAttribute="top" secondItem="eNj-JM-U7b" secondAttribute="bottom" id="JmA-4b-GkY"/>
+                            <constraint firstAttribute="width" secondItem="eNj-JM-U7b" secondAttribute="width" id="Ttg-sv-Sdr"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="eNj-JM-U7b" secondAttribute="trailing" constant="-16" id="aJi-Lk-z1e"/>
+                            <constraint firstItem="eNj-JM-U7b" firstAttribute="leading" secondItem="iwE-5s-5wc" secondAttribute="leadingMargin" constant="-16" id="mdq-bk-aRX"/>
                         </constraints>
+                        <variation key="default">
+                            <mask key="constraints">
+                                <exclude reference="9gL-hj-Scz"/>
+                                <exclude reference="AEi-r1-z7b"/>
+                                <exclude reference="Ttg-sv-Sdr"/>
+                            </mask>
+                        </variation>
                     </view>
                     <navigationItem key="navigationItem" title="You Are Here" id="U5e-J1-I0k">
                         <barButtonItem key="rightBarButtonItem" title="Cancel" id="MQ9-0u-pJ4">
@@ -141,13 +178,13 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
-                        <outlet property="contentViewBottomConstraint" destination="m6i-WB-pS3" id="Tt8-1z-gZF"/>
-                        <outlet property="scrollView" destination="eNj-JM-U7b" id="njx-xC-A6d"/>
+                        <outlet property="contentViewHeightConstraint" destination="gla-Ao-JP8" id="Jly-Sf-KkJ"/>
+                        <outlet property="scrollViewBottomConstraint" destination="JmA-4b-GkY" id="fHF-Zh-kP5"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="pHv-dv-GJe" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1750" y="385"/>
+            <point key="canvasLocation" x="2140" y="286"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="vCw-Ds-Pc0">

--- a/TestAL/ViewControllerWithScrollView.m
+++ b/TestAL/ViewControllerWithScrollView.m
@@ -11,8 +11,6 @@
 @interface ViewControllerWithScrollView ()
 @property (nonatomic, weak) IBOutlet NSLayoutConstraint *scrollViewBottomConstraint;
 @property (nonatomic, weak) IBOutlet NSLayoutConstraint *contentViewHeightConstraint;
-@property (nonatomic, weak) IBOutlet UIScrollView *scrollView;
-@property (nonatomic, weak) IBOutlet UIView *contentView;
 @end
 
 @implementation ViewControllerWithScrollView


### PR DESCRIPTION
I updated the project to solve the display issues you were having. The content view sizes itself to fill the screen while still being scrollable when the keyboard is displayed. This works on all display sizes in both portrait and landscape orientation. 

In a nutshell, what is happening is the content view that is contented inside the scroll view is sized during the `viewDidLayoutSubviews`. The sizing is done here as this is a safe place to reference properties of the `topLayoutGuide` and `bottomLayoutGuide`.

To handle scrolling when the keyboard is displayed, the bottom constraint on the scroll view is adjusted based on the keyboard end frame height.

Also note that I turned off the `automaticallyAdjustsScrollViewInsets` on the view controller since the scroll view's top and bottom constraints at pinned to the `topLayoutGuide` and `bottomLayoutGuide` respectively. If you don't do this, then the insets are adjusted based on any status bar and navigation bar that might be present.

Here is a good article on using scroll views with auto layout:

http://spin.atomicobject.com/2014/03/05/uiscrollview-autolayout-ios/

Basically the only thing I did differently was to adjust the content view's height to accommodate the navigation bar. The sample project in the article does not include the view in a navigation controller, so it adjusts the content view's size to match the main view's size.

Hope this helps.
